### PR TITLE
Update buildout setup to run on Python 3.13

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.1.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Update for Python 3.13
+  Refs. https://github.com/syslabcom/scrum/issues/4800
 
 
 1.1.2 (2026-01-21)

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PSQL_USER = postgres
 all: init-metabase
 
 .venv/bin/pip:
-	python3 -m venv .venv || virtualenv -p python3 --no-site-packages --no-setuptools .venv || virtualenv -p python3 --no-setuptools .venv
+	pipx run uv venv .venv --seed -p 3.13 || python3 -m venv .venv || virtualenv -p python3 --no-site-packages --no-setuptools .venv || virtualenv -p python3 --no-setuptools .venv
 	.venv/bin/python3 -m pip install --upgrade pip
 
 .venv/bin/buildout: .venv/bin/pip requirements.txt

--- a/picked-versions.cfg
+++ b/picked-versions.cfg
@@ -1,8 +1,13 @@
 [versions]
 alembic = 1.14.1
 backports.functools-lru-cache = 2.0.0
+certifi = 2026.4.22
+charset-normalizer = 3.4.7
 collective.recipe.genshi = 1.0
+collective.recipe.template = 2.2
+Genshi = 0.7.10
 greenlet = 3.1.1
+idna = 3.14
 importlib-metadata = 8.6.1
 importlib-resources = 6.5.2
 Mako = 1.3.9
@@ -10,8 +15,11 @@ MarkupSafe = 3.0.2
 metabase-api = 3.4.4
 mr.developer = 2.0.2
 psycopg2 = 2.9.10
+requests = 2.33.1
+six = 1.17.0
 SQLAlchemy = 2.0.38
 sqlparse = 0.5.3
 supervisor = 4.2.5
 typing-extensions = 4.12.2
+urllib3 = 2.7.0
 zipp = 3.21.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,1 @@
-setuptools==46.0.0
-zc.buildout==2.13.3
-genshi==0.7.7
-requests
+-r https://dist.plone.org/release/6.2.0rc2/requirements.txt


### PR DESCRIPTION
Updating constraints to make buildout ready for Python 3.13

- Update `setuptools` and `zc.buildout` for compatibility with Python 3.13,
where distutils is no longer available
- Pin `collective.recipe.template` to 2.2 because the previously resolved version 2.1 fails during buildout installation on Python 3.13.

Refs. https://github.com/syslabcom/scrum/issues/4800